### PR TITLE
Add support for CPU inference via a device parameter.

### DIFF
--- a/models/RT_stereo.py
+++ b/models/RT_stereo.py
@@ -128,8 +128,9 @@ def post_3dconvs(layers, channels):
     return nn.Sequential(*net)
 
 class RTStereoNet(nn.Module):
-    def __init__(self, maxdisp):
+    def __init__(self, maxdisp, device=torch.device('cuda')):
         super(RTStereoNet, self).__init__()
+        self.device = device
 
         self.feature_extraction = feature_extraction()
         self.maxdisp = maxdisp
@@ -171,8 +172,7 @@ class RTStereoNet(nn.Module):
         yy = yy.view(1, 1, H, W).repeat(B, 1, 1, 1)
         grid = torch.cat((xx, yy), 1).float()
 
-        if x.is_cuda:
-            vgrid = grid.cuda()
+        vgrid = grid.to(self.device)
         #vgrid = grid
         vgrid[:,:1,:,:] = vgrid[:,:1,:,:] - disp
 
@@ -185,10 +185,10 @@ class RTStereoNet(nn.Module):
         return output
 
 
-    def _build_volume_2d(self, feat_l, feat_r, maxdisp, stride=1):
+    def _build_volume_2d(self, feat_l, feat_r, maxdisp:int , stride: int = 1):
         assert maxdisp % stride == 0  # Assume maxdisp is multiple of stride
         b,c,h,w = feat_l.size()
-        cost = torch.zeros(b, 1, maxdisp//stride, h, w).cuda().requires_grad_(False)
+        cost = torch.zeros(b, 1, maxdisp//stride, h, w).to(self.device).requires_grad_(False)
         for i in range(0, maxdisp, stride):
             if i > 0:
                 cost[:, :, i//stride, :, i:] = torch.norm(feat_l[:, :, :, i:] - feat_r[:, :, :, :-i], p=1, dim = 1,keepdim=True)
@@ -200,7 +200,7 @@ class RTStereoNet(nn.Module):
         b,c,h,w = feat_l.size()
         batch_disp = disp[:,None,:,:,:].repeat(1, maxdisp*2-1, 1, 1, 1).view(-1,1,h,w)
         temp_array = np.tile(np.array(range(-maxdisp + 1, maxdisp)), b) * stride
-        batch_shift = torch.Tensor(np.reshape(temp_array, [len(temp_array), 1, 1, 1])).cuda().requires_grad_(False)
+        batch_shift = torch.Tensor(np.reshape(temp_array, [len(temp_array), 1, 1, 1])).to(self.device).requires_grad_(False)
         batch_disp = batch_disp - batch_shift
         batch_feat_l = feat_l[:,None,:,:,:].repeat(1,maxdisp*2-1, 1, 1, 1).view(-1,c,h,w)
         batch_feat_r = feat_r[:,None,:,:,:].repeat(1,maxdisp*2-1, 1, 1, 1).view(-1,c,h,w)
@@ -227,12 +227,12 @@ class RTStereoNet(nn.Module):
             cost = self.volume_postprocess[scale](cost)
             cost = cost.squeeze(1)
             if scale == 0:
-                pred_low_res = disparityregression2(0, 12)(F.softmax(cost, dim=1))
+                pred_low_res = disparityregression2(0, 12, self.device)(F.softmax(cost, dim=1))
                 pred_low_res = pred_low_res * img_size[2] / pred_low_res.size(2)
                 disp_up = F.upsample(pred_low_res, (img_size[2], img_size[3]), mode='bilinear')
                 pred.append(disp_up)
             else:
-                pred_low_res = disparityregression2(-2, 3, stride=1)(F.softmax(cost, dim=1))
+                pred_low_res = disparityregression2(-2, 3, self.device, stride=1)(F.softmax(cost, dim=1))
                 pred_low_res = pred_low_res * img_size[2] / pred_low_res.size(2) 
                 disp_up = F.upsample(pred_low_res, (img_size[2], img_size[3]), mode='bilinear')
                 pred.append(disp_up+pred[scale-1]) #
@@ -242,9 +242,9 @@ class RTStereoNet(nn.Module):
             return pred[-1]
 
 class disparityregression2(nn.Module):
-    def __init__(self, start, end, stride=1):
+    def __init__(self, start, end, device: torch.device, stride=1):
         super(disparityregression2, self).__init__()
-        self.disp = torch.arange(start*stride, end*stride, stride).view(1, -1, 1, 1).type(torch.FloatTensor).cuda().requires_grad_(False)
+        self.disp = torch.arange(start*stride, end*stride, stride).view(1, -1, 1, 1).type(torch.FloatTensor).to(device).requires_grad_(False)
     def forward(self, x):
         out = torch.sum(x * self.disp, 1, keepdim=True)
         return out


### PR DESCRIPTION
Hi, thanks for sharing your work. I wanted to test the model with CPU inference but the hardcoded .cuda() calls were preventing that, so I replaced them with .to(device), making it a parameter. Thought you might find it useful.